### PR TITLE
Changes viewer code to use aGroup.quizSize instead of summary.assessmentSize #33 

### DIFF
--- a/assets/js/viewer/obo.model.js
+++ b/assets/js/viewer/obo.model.js
@@ -1522,7 +1522,7 @@ obo.model = function()
 				}
 				else
 				{
-					return parseInt(lo.summary.assessmentSize, 10);
+					return parseInt(lo.aGroup.quizSize, 10);
 				}
 		}
 	};

--- a/assets/js/viewer/obo.view.js
+++ b/assets/js/viewer/obo.view.js
@@ -642,7 +642,7 @@ obo.view = function()
 		$("#key-words").text(lo.keywords.join(", "));
 		$("#content-size").text(lo.summary.contentSize + ' Pages');
 		$("#practice-size").text(lo.summary.practiceSize + ' Questions');
-		$("#assessment-size").text(lo.summary.assessmentSize + ' Questions');
+		$("#assessment-size").text(lo.aGroup.quizSize + ' Questions');
 		$('#get-started-button').attr('href', baseURL + obo.model.isResumingPreviousAttempt() ? '#/assessment/start' : '#/content/1');
 	};
 	


### PR DESCRIPTION
Solves an issue where summary.assessmentSize seems to be having the wrong value.

lo.aGroup.quizSize seems to always have the expected value, so I switched it to that.