### PR TITLE
Adds option to duplicate perms when lti instances are duplicated

### DIFF
--- a/internal/classes/rocketD/perms/PermManager.class.php
+++ b/internal/classes/rocketD/perms/PermManager.class.php
@@ -120,27 +120,32 @@ abstract class PermManager extends \rocketD\db\DBEnabled
 		return $allItems;
 	}
 
+	public function duplictePermsToNewItem($itemType, $oldItemID, $newItemId)
+	{
+		/** Validate Input **/
+		if(!\obo\util\Validator::isPosInt($oldItemID)) return \rocketD\util\Error::getError(2);
+		if(!\obo\util\Validator::isPosInt($newItemId)) return \rocketD\util\Error::getError(2);
+		if(!\obo\util\Validator::isPermItemType($itemType)) return \rocketD\util\Error::getError(2);
+
+
+		$query = "
+		INSERT INTO ".\cfg_core_Perm::TABLE."
+			(".\cfg_core_User::ID.", ".\cfg_core_Role::ID.", ".\cfg_core_Perm::ITEM.", ".\cfg_core_Perm::TYPE.", ".\cfg_core_Perm::PERM.")
+		SELECT
+			".\cfg_core_User::ID.", ".\cfg_core_Role::ID.", '?' as ".\cfg_core_Perm::ITEM.", ".\cfg_core_Perm::TYPE.", ".\cfg_core_Perm::PERM."
+		FROM ".\cfg_core_Perm::TABLE."
+		WHERE ".\cfg_core_Perm::ITEM." = '?'
+		AND ".\cfg_core_Perm::TYPE." = '?'";
+
+		$q = $this->DBM->querySafe($query, $newItemId, $oldItemID, $itemType);
+	}
 
 	public function getAllUsersIDsForItem($itemType, $itemID, $includeGroupRights=false)
 	{
 		/** Validate Input **/
+		if(!\obo\util\Validator::isPosInt($itemID)) return \rocketD\util\Error::getError(2);
+		if(!\obo\util\Validator::isPermItemType($itemType)) return \rocketD\util\Error::getError(2);
 
-		if(!\obo\util\Validator::isPosInt($itemID))
-		{
-
-			return \rocketD\util\Error::getError(2);
-		}
-
-		if(!\obo\util\Validator::isPermItemType($itemType))
-		{
-
-			return \rocketD\util\Error::getError(2);
-		}
-		// TODO: enable group rights option, this would need to find users that are in groups that have rights to this item
-		if($includeGroupRights == true)
-		{
-			// we may not need to do this
-		}
 		$users = array();
 		$query = "SELECT ".\cfg_core_User::ID.", ".\cfg_core_Perm::PERM." FROM ".\cfg_core_Perm::TABLE." WHERE ".\cfg_core_Role::ID." ='0' AND ".\cfg_core_Perm::TYPE." = '?' AND ".\cfg_core_Perm::ITEM." = '?'";
 		$q = $this->DBM->querySafe($query, $itemType, $itemID);

--- a/internal/config/cfg.php
+++ b/internal/config/cfg.php
@@ -175,6 +175,7 @@ class AppCfgDefault
 	const LTI_REMOTE_USERNAME_FIELD = 'lis_person_sourcedid';
 	const LTI_CREATE_USER_IF_MISSING = true;
 	const LTI_USE_ROLE = true;
+	const LTI_COPY_PERMS_ON_DUPLICATE = true;
 
 	// REQUIRED CREDHUB @TODO - these shouldnt be required
 	const CREDHUB_KEY = 'key';


### PR DESCRIPTION
In some cases, this may be a bad idea - we're making some assumptions on who should own the new instance.

But, if we don't do this - it behave like NOONE expects - making a ghost instance you have to work to claim.

You can still claim an instance if you have teacher access to the course it's in.