### PR TITLE
Fix wrong state value for FormDateTime

### DIFF
--- a/internal/src/components/form-date-time.jsx
+++ b/internal/src/components/form-date-time.jsx
@@ -31,7 +31,7 @@ export default function FormDateTime({ value, onChange }) {
 		}
 
 		if (updatedDateTime.toString() !== 'Invalid Date') {
-			onChange(updatedDateTime.getTime())
+			onChange(updatedDateTime.getTime() / 1000)
 		}
 	}
 


### PR DESCRIPTION
The page sometimes crashes when typing the date manually.

Divide time value by 1000 to get the same input format.